### PR TITLE
Added optional Close button

### DIFF
--- a/AndroidLicensesPage/src/main/java/com/example/androidlicensespage/LicensesFragment.java
+++ b/AndroidLicensesPage/src/main/java/com/example/androidlicensespage/LicensesFragment.java
@@ -145,11 +145,11 @@ public class LicensesFragment extends DialogFragment {
             showCloseButton = arguments.getBoolean(KEY_SHOW_CLOSE_BUTTON);
         }
 
-        AlertDialog.Builder mBuilder = new AlertDialog.Builder(getActivity());
-        mBuilder.setTitle("Open Source licenses");
-        mBuilder.setView(content);
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle("Open Source licenses");
+        builder.setView(content);
         if (showCloseButton) {
-            mBuilder.setNegativeButton("Close",
+            builder.setNegativeButton("Close",
                 new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int id) {
@@ -158,7 +158,7 @@ public class LicensesFragment extends DialogFragment {
                 });
         }
 
-        return mBuilder.create();
+        return builder.create();
     }
 
     private void loadLicenses() {

--- a/AndroidLicensesPage/src/main/java/com/example/androidlicensespage/LicensesFragment.java
+++ b/AndroidLicensesPage/src/main/java/com/example/androidlicensespage/LicensesFragment.java
@@ -38,12 +38,11 @@ import android.webkit.WebView;
 import android.widget.ProgressBar;
 
 /**
- * Created by Adam Speakman on 24/09/13. 
+ * Created by Adam Speakman on 24/09/13.
  * http://speakman.net.nz
  */
 public class LicensesFragment extends DialogFragment {
 
-    private AlertDialog.Builder mBuilder;
     private AsyncTask<Void, Void, String> mLicenseLoader;
 
     private static final String FRAGMENT_TAG = "nz.net.speakman.androidlicensespage.LicensesFragment";
@@ -51,7 +50,7 @@ public class LicensesFragment extends DialogFragment {
 
     /**
      * Creates a new instance of LicensesFragment with no Close button.
-     * 
+     *
      * @return A new licenses fragment.
      */
     public static LicensesFragment newInstance() {
@@ -60,9 +59,9 @@ public class LicensesFragment extends DialogFragment {
 
     /**
      * Creates a new instance of LicensesFragment with an optional Close button.
-     * 
+     *
      * @param showCloseButton Whether to show a Close button at the bottom of the dialog.
-     * 
+     *
      * @return A new licenses fragment.
      */
     public static LicensesFragment newInstance(boolean showCloseButton) {
@@ -79,7 +78,7 @@ public class LicensesFragment extends DialogFragment {
      * Builds and displays a licenses fragment with no Close button. Requires
      * "/res/raw/licenses.html" and "/res/layout/licenses_fragment.xml" to be
      * present.
-     * 
+     *
      * @param fm A fragment manager instance used to display this LicensesFragment.
      */
     public static void displayLicensesFragment(FragmentManager fm) {
@@ -99,7 +98,7 @@ public class LicensesFragment extends DialogFragment {
      * Builds and displays a licenses fragment with or without a Close button.
      * Requires "/res/raw/licenses.html" and "/res/layout/licenses_fragment.xml"
      * to be present.
-     * 
+     *
      * @param fm A fragment manager instance used to display this LicensesFragment.
      * @param showCloseButton Whether to show a Close button at the bottom of the dialog.
      */
@@ -143,10 +142,10 @@ public class LicensesFragment extends DialogFragment {
         boolean showCloseButton = false;
         Bundle arguments = getArguments();
         if (arguments != null) {
-            showCloseButton = arguments.getBoolean(KEY_SHOW_CLOSE_BUTTON);    	
+            showCloseButton = arguments.getBoolean(KEY_SHOW_CLOSE_BUTTON);
         }
-    
-        mBuilder = new AlertDialog.Builder(getActivity());
+
+        AlertDialog.Builder mBuilder = new AlertDialog.Builder(getActivity());
         mBuilder.setTitle("Open Source licenses");
         mBuilder.setView(content);
         if (showCloseButton) {
@@ -192,13 +191,13 @@ public class LicensesFragment extends DialogFragment {
                 super.onPostExecute(licensesBody);
                 if (getActivity() == null || isCancelled()) {
                     return;
-                }	
+                }
                 mIndeterminateProgress.setVisibility(View.INVISIBLE);
                 mWebView.setVisibility(View.VISIBLE);
                 mWebView.loadDataWithBaseURL(null, licensesBody, "text/html", "utf-8", null);
                 mLicenseLoader = null;
             }
-            
+
         }.execute();
     }
 }

--- a/AndroidLicensesPageExampleProject/AndroidLicensesPageExample/src/main/java/com/example/androidlicensespageexample/LicensesFragment.java
+++ b/AndroidLicensesPageExampleProject/AndroidLicensesPageExample/src/main/java/com/example/androidlicensespageexample/LicensesFragment.java
@@ -145,11 +145,11 @@ public class LicensesFragment extends DialogFragment {
             showCloseButton = arguments.getBoolean(KEY_SHOW_CLOSE_BUTTON);
         }
 
-        AlertDialog.Builder mBuilder = new AlertDialog.Builder(getActivity());
-        mBuilder.setTitle("Open Source licenses");
-        mBuilder.setView(content);
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle("Open Source licenses");
+        builder.setView(content);
         if (showCloseButton) {
-            mBuilder.setNegativeButton("Close",
+            builder.setNegativeButton("Close",
                 new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int id) {
@@ -158,7 +158,7 @@ public class LicensesFragment extends DialogFragment {
                 });
         }
 
-        return mBuilder.create();
+        return builder.create();
     }
 
     private void loadLicenses() {

--- a/AndroidLicensesPageExampleProject/AndroidLicensesPageExample/src/main/java/com/example/androidlicensespageexample/LicensesFragment.java
+++ b/AndroidLicensesPageExampleProject/AndroidLicensesPageExample/src/main/java/com/example/androidlicensespageexample/LicensesFragment.java
@@ -16,43 +16,70 @@
 
 package com.example.androidlicensespageexample;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import android.annotation.SuppressLint;
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.DialogInterface;
 import android.os.AsyncTask;
 import android.os.Bundle;
-// TODO If you don't support Android 2.x, you should use the non-support version!
+//TODO If you don't support Android 2.x, you should use the non-support version!
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.view.ViewGroup;
 import android.webkit.WebView;
 import android.widget.ProgressBar;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-
-
 /**
- * Created by Adam Speakman on 24/09/13.
+ * Created by Adam Speakman on 24/09/13. 
  * http://speakman.net.nz
  */
 public class LicensesFragment extends DialogFragment {
 
+    private AlertDialog.Builder mBuilder;
     private AsyncTask<Void, Void, String> mLicenseLoader;
 
     private static final String FRAGMENT_TAG = "nz.net.speakman.androidlicensespage.LicensesFragment";
+    private static final String KEY_SHOW_CLOSE_BUTTON = "keyShowCloseButton";
 
+    /**
+     * Creates a new instance of LicensesFragment with no Close button.
+     * 
+     * @return A new licenses fragment.
+     */
     public static LicensesFragment newInstance() {
         return new LicensesFragment();
     }
 
     /**
-     * Builds and displays a licenses fragment for you. Requires "/res/raw/licenses.html" and
-     * "/res/layout/licenses_fragment.xml" to be present.
-     *
+     * Creates a new instance of LicensesFragment with an optional Close button.
+     * 
+     * @param showCloseButton Whether to show a Close button at the bottom of the dialog.
+     * 
+     * @return A new licenses fragment.
+     */
+    public static LicensesFragment newInstance(boolean showCloseButton) {
+        LicensesFragment fragment = new LicensesFragment();
+
+        Bundle bundle = new Bundle();
+        bundle.putBoolean(KEY_SHOW_CLOSE_BUTTON, showCloseButton);
+        fragment.setArguments(bundle);
+
+        return fragment;
+    }
+
+    /**
+     * Builds and displays a licenses fragment with no Close button. Requires
+     * "/res/raw/licenses.html" and "/res/layout/licenses_fragment.xml" to be
+     * present.
+     * 
      * @param fm A fragment manager instance used to display this LicensesFragment.
      */
     public static void displayLicensesFragment(FragmentManager fm) {
@@ -68,17 +95,25 @@ public class LicensesFragment extends DialogFragment {
         newFragment.show(ft, FRAGMENT_TAG);
     }
 
-    private WebView mWebView;
-    private ProgressBar mIndeterminateProgress;
+    /**
+     * Builds and displays a licenses fragment with or without a Close button.
+     * Requires "/res/raw/licenses.html" and "/res/layout/licenses_fragment.xml"
+     * to be present.
+     * 
+     * @param fm A fragment manager instance used to display this LicensesFragment.
+     * @param showCloseButton Whether to show a Close button at the bottom of the dialog.
+     */
+    public static void displayLicensesFragment(FragmentManager fm, boolean showCloseButton) {
+        FragmentTransaction ft = fm.beginTransaction();
+        Fragment prev = fm.findFragmentByTag(FRAGMENT_TAG);
+        if (prev != null) {
+            ft.remove(prev);
+        }
+        ft.addToBackStack(null);
 
-    @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        // TODO Extract this title out into your strings resource file.
-        getDialog().setTitle("Open Source licenses");
-        View view = inflater.inflate(R.layout.licenses_fragment, container, false);
-        mIndeterminateProgress = (ProgressBar)view.findViewById(R.id.licensesFragmentIndeterminateProgress);
-        mWebView = (WebView)view.findViewById(R.id.licensesFragmentWebView);
-        return view;
+        // Create and show the dialog.
+        DialogFragment newFragment = LicensesFragment.newInstance(showCloseButton);
+        newFragment.show(ft, FRAGMENT_TAG);
     }
 
     @Override
@@ -93,6 +128,38 @@ public class LicensesFragment extends DialogFragment {
         if (mLicenseLoader != null) {
             mLicenseLoader.cancel(true);
         }
+    }
+
+    private WebView mWebView;
+    private ProgressBar mIndeterminateProgress;
+
+    @SuppressLint("InflateParams")
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        View content = LayoutInflater.from(getActivity()).inflate(R.layout.licenses_fragment, null);
+        mWebView = (WebView) content.findViewById(R.id.licensesFragmentWebView);
+        mIndeterminateProgress = (ProgressBar) content.findViewById(R.id.licensesFragmentIndeterminateProgress);
+
+        boolean showCloseButton = false;
+        Bundle arguments = getArguments();
+        if (arguments != null) {
+            showCloseButton = arguments.getBoolean(KEY_SHOW_CLOSE_BUTTON);    	
+        }
+    
+        mBuilder = new AlertDialog.Builder(getActivity());
+        mBuilder.setTitle("Open Source licenses");
+        mBuilder.setView(content);
+        if (showCloseButton) {
+            mBuilder.setNegativeButton("Close",
+                new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int id) {
+                        dialog.dismiss();
+                    }
+                });
+        }
+
+        return mBuilder.create();
     }
 
     private void loadLicenses() {
@@ -123,13 +190,15 @@ public class LicensesFragment extends DialogFragment {
             @Override
             protected void onPostExecute(String licensesBody) {
                 super.onPostExecute(licensesBody);
-                if (getActivity() == null || isCancelled()) return;
+                if (getActivity() == null || isCancelled()) {
+                    return;
+                }	
                 mIndeterminateProgress.setVisibility(View.INVISIBLE);
                 mWebView.setVisibility(View.VISIBLE);
                 mWebView.loadDataWithBaseURL(null, licensesBody, "text/html", "utf-8", null);
                 mLicenseLoader = null;
             }
-
+            
         }.execute();
     }
 }

--- a/AndroidLicensesPageExampleProject/AndroidLicensesPageExample/src/main/java/com/example/androidlicensespageexample/LicensesFragment.java
+++ b/AndroidLicensesPageExampleProject/AndroidLicensesPageExample/src/main/java/com/example/androidlicensespageexample/LicensesFragment.java
@@ -38,12 +38,11 @@ import android.webkit.WebView;
 import android.widget.ProgressBar;
 
 /**
- * Created by Adam Speakman on 24/09/13. 
+ * Created by Adam Speakman on 24/09/13.
  * http://speakman.net.nz
  */
 public class LicensesFragment extends DialogFragment {
 
-    private AlertDialog.Builder mBuilder;
     private AsyncTask<Void, Void, String> mLicenseLoader;
 
     private static final String FRAGMENT_TAG = "nz.net.speakman.androidlicensespage.LicensesFragment";
@@ -51,7 +50,7 @@ public class LicensesFragment extends DialogFragment {
 
     /**
      * Creates a new instance of LicensesFragment with no Close button.
-     * 
+     *
      * @return A new licenses fragment.
      */
     public static LicensesFragment newInstance() {
@@ -60,9 +59,9 @@ public class LicensesFragment extends DialogFragment {
 
     /**
      * Creates a new instance of LicensesFragment with an optional Close button.
-     * 
+     *
      * @param showCloseButton Whether to show a Close button at the bottom of the dialog.
-     * 
+     *
      * @return A new licenses fragment.
      */
     public static LicensesFragment newInstance(boolean showCloseButton) {
@@ -79,7 +78,7 @@ public class LicensesFragment extends DialogFragment {
      * Builds and displays a licenses fragment with no Close button. Requires
      * "/res/raw/licenses.html" and "/res/layout/licenses_fragment.xml" to be
      * present.
-     * 
+     *
      * @param fm A fragment manager instance used to display this LicensesFragment.
      */
     public static void displayLicensesFragment(FragmentManager fm) {
@@ -99,7 +98,7 @@ public class LicensesFragment extends DialogFragment {
      * Builds and displays a licenses fragment with or without a Close button.
      * Requires "/res/raw/licenses.html" and "/res/layout/licenses_fragment.xml"
      * to be present.
-     * 
+     *
      * @param fm A fragment manager instance used to display this LicensesFragment.
      * @param showCloseButton Whether to show a Close button at the bottom of the dialog.
      */
@@ -143,10 +142,10 @@ public class LicensesFragment extends DialogFragment {
         boolean showCloseButton = false;
         Bundle arguments = getArguments();
         if (arguments != null) {
-            showCloseButton = arguments.getBoolean(KEY_SHOW_CLOSE_BUTTON);    	
+            showCloseButton = arguments.getBoolean(KEY_SHOW_CLOSE_BUTTON);
         }
-    
-        mBuilder = new AlertDialog.Builder(getActivity());
+
+        AlertDialog.Builder mBuilder = new AlertDialog.Builder(getActivity());
         mBuilder.setTitle("Open Source licenses");
         mBuilder.setView(content);
         if (showCloseButton) {
@@ -192,13 +191,13 @@ public class LicensesFragment extends DialogFragment {
                 super.onPostExecute(licensesBody);
                 if (getActivity() == null || isCancelled()) {
                     return;
-                }	
+                }
                 mIndeterminateProgress.setVisibility(View.INVISIBLE);
                 mWebView.setVisibility(View.VISIBLE);
                 mWebView.loadDataWithBaseURL(null, licensesBody, "text/html", "utf-8", null);
                 mLicenseLoader = null;
             }
-            
+
         }.execute();
     }
 }

--- a/AndroidLicensesPageExampleProject/AndroidLicensesPageExample/src/main/java/com/example/androidlicensespageexample/MainActivity.java
+++ b/AndroidLicensesPageExampleProject/AndroidLicensesPageExample/src/main/java/com/example/androidlicensespageexample/MainActivity.java
@@ -16,7 +16,6 @@ public class MainActivity extends ActionBarActivity {
         setContentView(R.layout.activity_main);
     }
 
-
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         // Inflate the menu; this adds items to the action bar if it is present.
@@ -25,12 +24,20 @@ public class MainActivity extends ActionBarActivity {
     }
 
     public void onLicensesClick(View view) {
+        /**
+         * Display it with no Close button.
+         */
         LicensesFragment.displayLicensesFragment(getSupportFragmentManager());
+
+        /**
+         * Display it with a Close button.
+         */
+        //LicensesFragment.displayLicensesFragment(getSupportFragmentManager(), true);
 
         /**
          * Alternatively, you can display it like a regular DialogFragment.
          */
-//        // Create & show a licenses fragment just as you would any other DialogFragment.
+        // Create & show a licenses fragment just as you would any other DialogFragment.
 //        FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
 //        Fragment prev = getSupportFragmentManager().findFragmentByTag("licensesDialogFragment");
 //        if (prev != null) {
@@ -39,9 +46,8 @@ public class MainActivity extends ActionBarActivity {
 //        ft.addToBackStack(null);
 //
 //        // Create and show the dialog.
+//        // Use LicensesFragment.newInstance(true) to show a Close button.
 //        DialogFragment newFragment = LicensesFragment.newInstance();
 //        newFragment.show(ft, "licensesDialogFragment");
     }
-
-
 }


### PR DESCRIPTION
Hi Adam,

This gives the client the option to show a "Close" button at the bottom of the licenses page. It maintains backwards-compatibility so you can still use the old creation methods to display the dialog fragment.

I wanted to give end-users who aren't that familiar with Android a simple way to close the dialog in portrait mode instead of them accidentally hitting the Home button and exiting the app. I think it also gives it a nice professional look, even though the dialog looks very nice as it is :)

I used a standard method of displaying buttons on a DialogFragment by having it return an AlertDialog from `onCreateDialog()`, where the AlertDialog's content is set to `licenses_fragment.xml`.

Try it out and let me know what you think.
